### PR TITLE
Switch target avatar size to 72KB (matches Android)

### DIFF
--- a/Snikket/util/MediaHelper.swift
+++ b/Snikket/util/MediaHelper.swift
@@ -126,23 +126,24 @@ class MediaHelper {
         }
     }
     
-    static func resizeTo200KB(image: UIImage, completion: @escaping(UIImage?)->()) {
+    static func resizeTo(image: UIImage, targetBytes: UInt, completion: @escaping(UIImage?)->()) {
         guard let imageData = image.pngData() else {
             completion(nil)
             return
         }
 
         var resizingImage = image
-        var imageSizeKB = Double(imageData.count) / 1000.0 // ! Or devide for 1024 if you need KB but not kB
-
-        while imageSizeKB > 200 { // ! Or use 1024 if you need KB but not kB
-            guard let resizedImage = resizingImage.resized(withPercentage: 0.9),
+        var imageSizeBytes = imageData.count
+        
+        while imageSizeBytes > targetBytes {
+            guard let resizedImage = resizingImage.resized(withPercentage: 0.75),
                   let imageData = resizedImage.pngData()
-                else { completion(nil)
-                return }
-
+            else {
+                completion(nil)
+                return
+            }
+            imageSizeBytes = imageData.count
             resizingImage = resizedImage
-            imageSizeKB = Double(imageData.count) / 1000.0 // ! Or devide for 1024 if you need KB but not kB
         }
 
         return completion(resizingImage)

--- a/Snikket/vcard/VCardEditViewController.swift
+++ b/Snikket/vcard/VCardEditViewController.swift
@@ -195,8 +195,8 @@ class VCardEditViewController: UITableViewController, UIImagePickerControllerDel
         let data = photo.pngData()
         
         if let data = data {
-            if data.count > 200000 {     // 200KB
-                MediaHelper.resizeTo200KB(image: photo) { image in
+            if data.count > 72000 { // 72KB
+                MediaHelper.resizeTo(image: photo, targetBytes: 72000) { image in
                     if let image = image, let data = image.pngData() {
                         self.publishAvatar(data: data)
                         self.vcard.photos = [VCard.Photo(type: "image/png", binval: data.base64EncodedString(options: NSData.Base64EncodingOptions(rawValue: 0)))]


### PR DESCRIPTION
Also some minor code refactoring, to make the resize function generic and reusable. Increased step size to 25% on the assumption that fewer resize steps will result in better quality, and large images are probably photos that will require quite some shrinking.