### PR TITLE
Preserve pushkitDeviceId when re-enabling

### DIFF
--- a/Snikket/xmpp/SiskinPushNotificationsModule.swift
+++ b/Snikket/xmpp/SiskinPushNotificationsModule.swift
@@ -160,7 +160,7 @@ open class SiskinPushNotificationsModule: TigasePushNotificationsModule {
     }
     
     open func reenable(pushSettings: PushSettings, completionHandler: @escaping (Result<PushSettings,ErrorCondition>)->Void) {
-        self.enable(serviceJid: pushSettings.jid, node: pushSettings.node, deviceId: pushSettings.deviceId, features: pushSettings.encryption ? [TigasePushNotificationsModule.Encryption.XMLNS] : [], maxSize: pushSettings.maxSize, completionHandler: completionHandler);
+        self.enable(serviceJid: pushSettings.jid, node: pushSettings.node, deviceId: pushSettings.deviceId, pushkitDeviceId: pushSettings.pushkitDeviceId, features: pushSettings.encryption ? [TigasePushNotificationsModule.Encryption.XMLNS] : [], maxSize: pushSettings.maxSize, completionHandler: completionHandler);
     }
     
     private func hash(extensions: [PushNotificationsModuleExtension]) -> Int {


### PR DESCRIPTION
This is called in some circumstances, such as when modifying MUC push
settings. As pushkitDeviceId was not extracted and passed back to enable()
it defaulted to nil and was lost.

This triggered a push re-register on subsequent connections (because the
stored pushkitDeviceId (nil) did not match the one from the system).