### PR TITLE
Default MUCs to "always" notify

### DIFF
--- a/Snikket/database/DBChatStore.swift
+++ b/Snikket/database/DBChatStore.swift
@@ -998,7 +998,7 @@ public protocol ChatOptionsProtocol {
 public struct RoomOptions: Codable, ChatOptionsProtocol {
     
     var encryption: ChatEncryption?;
-    public var notifications: ConversationNotification = .mention;
+    public var notifications: ConversationNotification = .always;
     
     init() {}
     
@@ -1007,7 +1007,7 @@ public struct RoomOptions: Codable, ChatOptionsProtocol {
         if let val = try container.decodeIfPresent(String.self, forKey: .encryption) {
             encryption = ChatEncryption(rawValue: val);
         }
-        notifications = ConversationNotification(rawValue: try container.decodeIfPresent(String.self, forKey: .notifications) ?? "") ?? .mention;
+        notifications = ConversationNotification(rawValue: try container.decodeIfPresent(String.self, forKey: .notifications) ?? "") ?? .always;
     }
     
     public func encode(to encoder: Encoder) throws {
@@ -1015,7 +1015,7 @@ public struct RoomOptions: Codable, ChatOptionsProtocol {
         if encryption != nil {
             try container.encode(encryption!.rawValue, forKey: .encryption);
         }
-        if notifications != .mention {
+        if notifications != .always {
             try container.encode(notifications.rawValue, forKey: .notifications);
         }
     }


### PR DESCRIPTION
Rationale:

- Snikket is focused mostly on the private group chat use-case, not public
  channels. Usually the preference is for notification on all messages in
  private groups.
- This is the default behaviour on the server side, unless overridden by the
  client.
- The server can't default to "mentioned" because it doesn't necessarily know
  the user's nick within a MUC.
- The client doesn't configure immediately upon joining a MUC (actually only
  when the user explicitly modifies the MUC notification settings, currently)

In the future it would be good if we can default to "mention" for public MUCs,
but this will probably need a bit more work and possibly client-server
protocol changes.