### PR TITLE
Fixed sending bad-request errors on each received PubSub notification

### DIFF
--- a/Snikket/service/PEPDisplayNameModule.swift
+++ b/Snikket/service/PEPDisplayNameModule.swift
@@ -22,7 +22,7 @@ class PEPDisplayNameModule: AbstractPEPModule {
     
     var id = ID
     
-    var criteria = Criteria.name("message").add(Criteria.name("event", xmlns: PUBSUB_EVENT_XMLNS));
+    var criteria = Criteria.empty();
     
     var features: [String] = FEATURES
     


### PR DESCRIPTION
This module returns `bad-request` errors for each stanza it processes. As it should not process stanzas directly, it works on pubsub notifications received from `PubSubModule`, `criteria` should be set to `Criteria.empty()` to ensure no stanza will be directed to this module for processing.