### PR TITLE
Fix chat composer overlapping sidebar in split view

### DIFF
--- a/Snikket/chat/BaseChatViewController.swift
+++ b/Snikket/chat/BaseChatViewController.swift
@@ -87,8 +87,8 @@ class BaseChatViewController: UIViewController, UITextViewDelegate, ChatViewInpu
         NSLayoutConstraint.activate([
             chatViewInputBar.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
             chatViewInputBar.topAnchor.constraint(equalTo: containerView.bottomAnchor),
-            chatViewInputBar.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
-            chatViewInputBar.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+            chatViewInputBar.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
+            chatViewInputBar.trailingAnchor.constraint(equalTo: containerView.trailingAnchor)
             //chatViewInputBar.heightAnchor.constraint(equalToConstant: 60)
         ]);
 


### PR DESCRIPTION
The input bar was constrained to the root view’s leading/trailing edges, so on newer split-view behavior it could extend under the sidebar. Constrain it to `containerView` leading/trailing instead so it stays within the chat detail pane.

This issue is currently impacting the app on iPad with the latest app release, which was built using newer macOS.