### PR TITLE
Force bottom tab bar mode

### DIFF
--- a/Snikket/ui/MainTabBarController.swift
+++ b/Snikket/ui/MainTabBarController.swift
@@ -31,6 +31,10 @@ class MainTabBarController: CustomTabBarController, UITabBarControllerDelegate {
     override func viewDidLoad() {
         super.viewDidLoad();
         
+        if #available(iOS 18.0, *) {
+            self.mode = .tabBar;
+        }
+        
         self.delegate = self;
         
         NotificationCenter.default.addObserver(self, selector: #selector(updateMoreBadge), name: XmppService.ACCOUNT_STATE_CHANGED, object: nil);


### PR DESCRIPTION
Explicitly set `UITabBarController` mode to `.tabBar` in `MainTabBarController.viewDidLoad` when building on newer macOS.

This prevents automatic sidebar-style/tab adaptation on newer OS versions (which can render large text tabs at the top and overflow into a “more” chevron on narrow sidebars), and keeps the expected bottom icon tab layout (Chats, Contacts, Settings).

The issue was appearing when running the new iPad app on older OS versions, particularly when running the iPad app on macOS Sequoia.