### PR TITLE
Fix truncated tappable URLs in chat messages with emoji/unicode

### DIFF
--- a/Snikket/chat/ChatTableViewCell.swift
+++ b/Snikket/chat/ChatTableViewCell.swift
@@ -75,7 +75,7 @@ class ChatTableViewCell: BaseChatTableViewCell, UITextViewDelegate {
         let attrText = NSMutableAttributedString(string: item.message);
             
         if let detect = try? NSDataDetector(types: NSTextCheckingResult.CheckingType.link.rawValue | NSTextCheckingResult.CheckingType.phoneNumber.rawValue) {
-            let matches = detect.matches(in: item.message, options: .reportCompletion, range: NSMakeRange(0, item.message.count));
+            let matches = detect.matches(in: item.message, options: .reportCompletion, range: NSRange(item.message.startIndex..., in: item.message));
             for match in matches {
                 var url: URL? = nil;
                 if match.url != nil {


### PR DESCRIPTION
When linkifying chat message text, `NSDataDetector` was called with `NSMakeRange(0, item.message.count)`.

`String.count` is not always the correct length for Foundation `NSRange` operations. In messages containing emoji or other multi-unit unicode characters, detection could stop early and produce a tappable link range that missed trailing URL characters.

Switch to a Foundation-safe range:
`NSRange(item.message.startIndex..., in: item.message)`

This preserves full URL tap targets in mixed unicode + URL messages.

This can be tested by sending this message, where the "ZZ" at the end would incorrectly not be part of the link:

```
🙂🙂 https://example.com/abcdefghijklmnopqrstuvwxyzZZ
```

Fixes https://github.com/snikket-im/snikket-ios/issues/221