### PR TITLE
Implement a simulator-only "no WebRTC" mode

### DIFF
--- a/Snikket/AppDelegate.swift
+++ b/Snikket/AppDelegate.swift
@@ -24,7 +24,9 @@ import UserNotifications
 import TigaseSwift
 import Sentry
 import Shared
+#if !targetEnvironment(simulator)
 import WebRTC
+#endif
 import BackgroundTasks
 
 @UIApplicationMain
@@ -62,9 +64,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
         try! DBConnection.migrateToGroupIfNeeded();
         ImageCache.convertToAttachments();
-//        RTCInitFieldTrialDictionary([:]);
+        #if !targetEnvironment(simulator)
+        //RTCInitFieldTrialDictionary([:]);
         RTCInitializeSSL();
         //RTCSetupInternalTracer();
+        #endif
         Log.initialize();
         Settings.initialize();
         
@@ -269,8 +273,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+        #if !targetEnvironment(simulator)
         RTCShutdownInternalTracer();
         RTCCleanupSSL();
+        #endif
         print(NSDate(), "application terminated!")
     }
 
@@ -788,4 +794,3 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
 
 }
-

--- a/Snikket/NotificationCenterDelegate.swift
+++ b/Snikket/NotificationCenterDelegate.swift
@@ -21,7 +21,6 @@
 
 import UIKit
 import Shared
-import WebRTC
 import TigaseSwift
 import UserNotifications
 

--- a/Snikket/voip/CameraPreviewView.swift
+++ b/Snikket/voip/CameraPreviewView.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import UIKit
 import AVFoundation
 import WebRTC
@@ -127,3 +128,4 @@ class CameraPreviewView: UIView {
         }
     }
 }
+#endif

--- a/Snikket/voip/ExternalServiceDiscovery_Service_extension.swift
+++ b/Snikket/voip/ExternalServiceDiscovery_Service_extension.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import Foundation
 import Network
 import WebRTC
@@ -69,3 +70,4 @@ extension ExternalServiceDiscoveryModule.Service {
         }
     }
 }
+#endif

--- a/Snikket/voip/JingleManager.swift
+++ b/Snikket/voip/JingleManager.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import Foundation
 import TigaseSwift
 import WebRTC
@@ -314,3 +315,4 @@ extension JingleManager {
     }
         
 }
+#endif

--- a/Snikket/voip/JingleManager_Session.swift
+++ b/Snikket/voip/JingleManager_Session.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import Foundation
 import TigaseSwift
 import WebRTC
@@ -262,3 +263,4 @@ protocol JingleSessionDelegate: class {
     func sessionTerminated(session: JingleManager.Session);
     func session(_ session: JingleManager.Session, didReceive: RTCIceCandidate);
 }
+#endif

--- a/Snikket/voip/RTCCameraVideoCapturer_Format.swift
+++ b/Snikket/voip/RTCCameraVideoCapturer_Format.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import Foundation
 import WebRTC
 
@@ -59,3 +60,4 @@ extension RTCCameraVideoCapturer {
     }
         
 }
+#endif

--- a/Snikket/voip/VideoCallController.swift
+++ b/Snikket/voip/VideoCallController.swift
@@ -19,6 +19,7 @@
 // If not, see https://www.gnu.org/licenses/.
 //
 
+#if !targetEnvironment(simulator)
 import UIKit
 import WebRTC
 import TigaseSwift
@@ -489,3 +490,4 @@ public class VideoCallController: UIViewController, CallManagerDelegate {
     }
 
 }
+#endif


### PR DESCRIPTION
Implemented a simulator-only "no WebRTC" mode so the app can be built/tested on iOS Simulator without rebuilding the WebRTC binary.

What I changed:

- Added simulator stubs for `CallManager`, `Call`, `JingleManager`, and `VideoCallController` in `CallManager.swift`
- Wrapped real WebRTC-heavy files so they only compile on non-simulator
- Guarded WebRTC lifecycle calls/import in `AppDelegate.swift`

Expected behavior:

- Simulator: calls/WebRTC are disabled, app should build without the incompatible WebRTC slice
- Real device: existing WebRTC call path remains unchanged