### PR TITLE
Fix iOS incoming call continuing to ring when answered on another device

### DIFF
--- a/Snikket/voip/JingleManager.swift
+++ b/Snikket/voip/JingleManager.swift
@@ -145,7 +145,13 @@ class JingleManager: JingleSessionManager, XmppServiceEventHandler {
                     }
                     self.sessionTerminated(account: account, sid: id);
                 case .proceed(let id):
-                    guard CallManager.isAvailable, let session = self.session(for: e.sessionObject.userBareJid!, with: e.jid, sid: id) else {
+                    let account = e.sessionObject.userBareJid!;
+                    // Another of our resources accepted this incoming call.
+                    if e.jid.bareJid == account {
+                        self.sessionTerminated(account: account, sid: id);
+                        return;
+                    }
+                    guard CallManager.isAvailable, let session = self.session(for: account, with: e.jid, sid: id) else {
                         return;
                     }
                     session.accepted(by: e.jid);


### PR DESCRIPTION
Handle Jingle Message Initiation `.proceed` from the same bare account as "answered elsewhere". When this self/carbon event is received, terminate the matching call session by `sid` instead of trying to resolve it by remote `jid`, so CallKit ringing stops on iOS after Android answers.