### PR TITLE
Fix memory leak by making `BaseChatTableViewCell.cellDelegate` weak

### DIFF
--- a/Snikket/chat/BaseChatTableViewCell.swift
+++ b/Snikket/chat/BaseChatTableViewCell.swift
@@ -22,7 +22,7 @@
 import UIKit
 import AVKit
 
-protocol CellDelegate {
+protocol CellDelegate: AnyObject {
     func didPlayAudio(audioPlayer: AVAudioPlayer, audioTimer: Foundation.Timer, sliderTimer: Foundation.Timer, playButton: UIButton)
     func didStopAudio()
     func didTapResend(indexPath: IndexPath)
@@ -61,7 +61,7 @@ class BaseChatTableViewCell: UITableViewCell, UIDocumentInteractionControllerDel
     @IBOutlet weak var lockStateImageView: UIImageView?
     var indexPath: IndexPath?
     
-    var cellDelegate: CellDelegate?
+    weak var cellDelegate: CellDelegate?
 
     var originalTimestampColor: UIColor!;
         


### PR DESCRIPTION
Repeatedly opening a conversation could keep old chat view controllers alive, causing memory usage to grow over time.

This fixes a retain cycle in chat cells by making `BaseChatTableViewCell.cellDelegate` a weak reference and constraining `CellDelegate` to `AnyObject`.

Before:
`ChatViewController -> view -> tableView -> cell -> cellDelegate -> ChatViewController`

After:
`ChatViewController -> view -> tableView -> cell -weak-> cellDelegate -> ChatViewController`

`ChatViewController` and `MucChatViewController` assign themselves as the cell delegate. With a strong delegate reference, visible cells can retain the owning conversation controller and prevent it from being deallocated after the UI navigates away or replaces the detail view.