### PR TITLE
Fix potential missing messages in MUC when catching up with MAM

### DIFF
--- a/Snikket/database/DBChatStore.swift
+++ b/Snikket/database/DBChatStore.swift
@@ -883,6 +883,7 @@ class DBRoom: Room, DBChatProtocol {
         if lastActivity != nil {
             self.lastActivity = lastActivity;
             self.timestamp = timestamp;
+            self.lastMessageDate = timestamp;
         }
         
         return true;

--- a/Snikket/service/MucEventHandler.swift
+++ b/Snikket/service/MucEventHandler.swift
@@ -111,7 +111,8 @@ class MucEventHandler: XmppServiceEventHandler {
 
             DBChatHistoryStore.instance.append(for: room.account, message: e.message, source: .stream)
             
-            DBLastMessageSyncStore.instance.updateOrInsertLastMessage(account: room.account, jid: room.roomJid, receivedId: e.message.id, readId: nil)
+            let receivedId = e.message.stanzaId?[room.roomJid]
+            DBLastMessageSyncStore.instance.updateOrInsertLastMessage(account: room.account, jid: room.roomJid, receivedId: receivedId, readId: nil)
         case let e as MucModule.AbstractOccupantEvent:
             if let room = e.room as? DBRoom, room.isOMEMOCapable, let jid = e.occupant.jid {
                 if (e.occupant.affiliation == .none || e.occupant.affiliation == .outcast) {


### PR DESCRIPTION
In the scenario where the client has disconnected, and later reconnects and tries to restore history using MAM, we send the wrong `after-id`, which would cause it to potentially miss getting messages in some cases.

The code was grabbing `message/@id`, and not `message/stanza-id/@id`. This PR fixes that.

For the date-based history fetch case (i.e. when we don't have MAM `stanza-id`), we'll keep `lastMessageDate` updated in DBChatStore. This may not necessarily be required, but should be more correct.

This is a potential unconfirmed fix for https://github.com/snikket-im/snikket-ios/issues/233.